### PR TITLE
Use `final` on classes that are not overriden

### DIFF
--- a/Sources/LangKit/Alignment/IBMModel2.swift
+++ b/Sources/LangKit/Alignment/IBMModel2.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Richard Wei. All rights reserved.
 //
 
-public class IBMModel2 : IBMModel1 {
+public final class IBMModel2 : IBMModel1 {
 
     typealias WordKey = ArrayKey<String>
     typealias AlignKey = ArrayKey<Int>

--- a/Sources/LangKit/FileIO/ParallelCorpusReader.swift
+++ b/Sources/LangKit/FileIO/ParallelCorpusReader.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class ParallelCorpusReader {
+public final class ParallelCorpusReader {
 
     public typealias SentenceTuple = ([String], [String])
 

--- a/Sources/LangKit/FileIO/TokenCorpusReader.swift
+++ b/Sources/LangKit/FileIO/TokenCorpusReader.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class TokenCorpusReader : CorpusReader<String> {
+public final class TokenCorpusReader : CorpusReader<String> {
 
     public required init?(fromFile path: String,
                  sentenceSeparator: String = "\n",

--- a/Sources/LangKit/SequenceLabeling/HiddenMarkovModel.swift
+++ b/Sources/LangKit/SequenceLabeling/HiddenMarkovModel.swift
@@ -52,7 +52,7 @@ public struct Emission<T: Hashable, U: Hashable> : Hashable {
 /**
  * Lazily cached hidden Markov model for sequence labeling
  */
-public class HiddenMarkovModel<Item: Hashable, Label: Hashable> {
+public final class HiddenMarkovModel<Item: Hashable, Label: Hashable> {
 
     public typealias TransitionType = Transition<Label>
     public typealias EmissionType = Emission<Label, Item>

--- a/Sources/LangKit/SequenceLabeling/PartOfSpeechTagger.swift
+++ b/Sources/LangKit/SequenceLabeling/PartOfSpeechTagger.swift
@@ -6,7 +6,7 @@
 //
 //
 
-public class PartOfSpeechTagger {
+public final class PartOfSpeechTagger {
 
     let model: HiddenMarkovModel<String, String>
 


### PR DESCRIPTION
On a 1.3 GHz Skylake MacBook, this resulted in a 3.4% speed up on the test suite, averaged across 5 runs.